### PR TITLE
Multi process import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'coffee-rails', '~> 4.2'
 gem 'jquery-rails'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
+gem 'smarter_csv'
+gem 'parallel'
 
 
 gem 'activerecord-insert_many', github: 'cph/activerecord-insert_many'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    parallel (1.10.0)
     pastel (0.7.1)
       equatable (~> 0.5.0)
       tty-color (~> 0.4.0)
@@ -212,6 +213,7 @@ GEM
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     slop (3.6.0)
+    smarter_csv (1.1.4)
     spring (2.0.1)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -259,6 +261,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  parallel
   pastel
   pg (~> 0.18)
   puma (~> 3.7)
@@ -269,6 +272,7 @@ DEPENDENCIES
   sass-rails!
   selenium-webdriver
   shoulda-matchers (~> 3.1)
+  smarter_csv
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/interactors/importer.rb
+++ b/app/interactors/importer.rb
@@ -14,7 +14,7 @@ class Importer
     importer = new(dir)
 
     [
-      :agency,
+      :agencies,
       :calendar,
       :calendar_dates,
       :routes,
@@ -25,7 +25,7 @@ class Importer
     ].each(&importer.method(:send))
   end
 
-  def agency
+  def agencies
     progress_bar(:agency) do |pbar|
       imported_data = clean_csv(:agency) do |obj|
         timestamps! obj

--- a/db/migrate/20170423170047_add_timestamp_defaults.rb
+++ b/db/migrate/20170423170047_add_timestamp_defaults.rb
@@ -1,0 +1,8 @@
+class AddTimestampDefaults < ActiveRecord::Migration[5.0]
+  def change
+    %w(stops agencies calendar_dates calendars routes shapes stop_times stops trips).each do |table_name|
+      change_column_default table_name, :created_at, from: nil, to: -> { 'CURRENT_TIMESTAMP' }
+      change_column_default table_name, :updated_at, from: nil, to: -> { 'CURRENT_TIMESTAMP' }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170403122432) do
+ActiveRecord::Schema.define(version: 20170423170047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,16 +25,16 @@ ActiveRecord::Schema.define(version: 20170403122432) do
     t.string   "agency_phone"
     t.string   "agency_fare_url"
     t.string   "agency_email"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",      default: -> { "now()" }, null: false
+    t.datetime "updated_at",      default: -> { "now()" }, null: false
   end
 
   create_table "calendar_dates", force: :cascade do |t|
     t.string   "service_id"
     t.datetime "date"
     t.integer  "exception_type"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",     default: -> { "now()" }, null: false
+    t.datetime "updated_at",     default: -> { "now()" }, null: false
   end
 
   create_table "calendars", force: :cascade do |t|
@@ -48,8 +48,8 @@ ActiveRecord::Schema.define(version: 20170403122432) do
     t.integer  "sunday"
     t.datetime "start_date"
     t.datetime "end_date"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", default: -> { "now()" }, null: false
+    t.datetime "updated_at", default: -> { "now()" }, null: false
   end
 
   create_table "routes", force: :cascade do |t|
@@ -62,8 +62,8 @@ ActiveRecord::Schema.define(version: 20170403122432) do
     t.string   "route_url"
     t.string   "route_color"
     t.string   "route_text_color"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "created_at",       default: -> { "now()" }, null: false
+    t.datetime "updated_at",       default: -> { "now()" }, null: false
   end
 
   create_table "shapes", force: :cascade do |t|
@@ -71,8 +71,8 @@ ActiveRecord::Schema.define(version: 20170403122432) do
     t.geography "shape_pt_latlon",     limit: {:srid=>4326, :type=>"point", :geographic=>true}
     t.integer   "shape_pt_sequence"
     t.decimal   "shape_dist_traveled"
-    t.datetime  "created_at",                                                                   null: false
-    t.datetime  "updated_at",                                                                   null: false
+    t.datetime  "created_at",                                                                   default: -> { "now()" }, null: false
+    t.datetime  "updated_at",                                                                   default: -> { "now()" }, null: false
   end
 
   create_table "stop_times", force: :cascade do |t|
@@ -90,8 +90,8 @@ ActiveRecord::Schema.define(version: 20170403122432) do
     t.integer  "drop_off_type",       default: 0
     t.decimal  "shape_dist_traveled"
     t.decimal  "timepoint"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at",          default: -> { "now()" }, null: false
+    t.datetime "updated_at",          default: -> { "now()" }, null: false
     t.index ["stop_id"], name: "index_stop_times_on_stop_id", using: :btree
     t.index ["trip_id"], name: "index_stop_times_on_trip_id", using: :btree
   end
@@ -108,8 +108,8 @@ ActiveRecord::Schema.define(version: 20170403122432) do
     t.string    "parent_station"
     t.string    "timezone"
     t.integer   "wheelchair_boarding"
-    t.datetime  "created_at",                                                                               null: false
-    t.datetime  "updated_at",                                                                               null: false
+    t.datetime  "created_at",                                                                   default: -> { "now()" }, null: false
+    t.datetime  "updated_at",                                                                   default: -> { "now()" }, null: false
   end
 
   create_table "trips", force: :cascade do |t|
@@ -123,8 +123,8 @@ ActiveRecord::Schema.define(version: 20170403122432) do
     t.string   "shape_id"
     t.integer  "wheelchair_accesible", default: 0
     t.integer  "bikes_allowed",        default: 0
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.datetime "created_at",           default: -> { "now()" }, null: false
+    t.datetime "updated_at",           default: -> { "now()" }, null: false
   end
 
 end

--- a/lib/tasks/feeds.rake
+++ b/lib/tasks/feeds.rake
@@ -1,3 +1,5 @@
+TYPES_TO_IMPORT = %w(agencies calendar_dates calendars routes shapes stop_times stops trips)
+
 namespace :feeds do
   pastel = Pastel.new
 
@@ -33,12 +35,25 @@ namespace :feeds do
     puts pastel.green('Fetch complete! 🚌')
   end
 
+  namespace :import do
+    TYPES_TO_IMPORT.each do |type|
+      desc "Import most recent download of #{type.pluralize} to the database"
+      task type => :environment do
+        Importer.new(Rails.root.join('tmp', 'gtfs')).send(type)
+      end
+    end
+  end
+
   desc "Import most recent download to the database"
   task import: :environment do
     Importer.import_all(Rails.root.join('tmp', 'gtfs'))
   end
 
-  desc "TODO"
+  desc "Delete rows from imported tables"
   task erase: :environment do
+    TYPES_TO_IMPORT.each do |type|
+      puts "Clearing #{type}"
+      type.classify.constantize.delete_all
+    end
   end
 end

--- a/spec/interactors/importer_spec.rb
+++ b/spec/interactors/importer_spec.rb
@@ -14,7 +14,7 @@ describe Importer do
     end
   end
 
-  { "agency" => 1,
+  { "agencies" => 1,
     "calendar_dates" => 6,
     "calendar" => 6,
     "routes" =>5,


### PR DESCRIPTION
@genebot 

The importer stopped being able to work on my machine reliably. I found this gem [parallel](https://github.com/grosser/parallel) to use multiple processes and then `smarter_csv` to insert into the database in chunks vs. all at once.

[This is the commit with most of the pertinent changes](https://github.com/cacqw7/stl-metro/pull/6/commits/2c82308709ffafd8f8cd807c28194e342292fbd2)

I'm definitely open for suggestions/arguments against this approach. I think chunking and then throwing to `sidekiq` is the ultimate goal, but these changes alleviated some of the major pain I was feeling with imports. I _think_ they're around 15 minutes now, but I haven't done any proper benchmarking yet. Wanted to get something up here to hear your feedback.

This is branched off of your `distance` branch.

I've also extended the `feedback` rake task and made Postgres responsible for default timestamp values.