### PR TITLE
Routes list

### DIFF
--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -1,0 +1,5 @@
+class RoutesController < ApplicationController
+  def index
+    @routes = Route.all
+  end
+end

--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -2,4 +2,8 @@ class RoutesController < ApplicationController
   def index
     @routes = Route.all
   end
+
+  def show
+    @route = Route.find(params[:id])
+  end
 end

--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -1,6 +1,8 @@
 class RoutesController < ApplicationController
   def index
-    @routes = Route.all
+    @routes = Route.all.sort_by do |route|
+      route.route_short_name.to_i
+    end
   end
 
   def show

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -4,4 +4,8 @@ class Route < ApplicationRecord
   validates_presence_of :route_short_name,
                         :route_long_name,
                         :route_type
+
+  def name
+    "#{route_short_name} #{route_long_name}"
+  end
 end

--- a/app/views/routes/index.html.erb
+++ b/app/views/routes/index.html.erb
@@ -6,7 +6,7 @@
   <div class="list-group">
     <% @routes.each do |route| %>
       <div class="list-group-item">
-        <%= route.name %>
+        <%= link_to route.name, route %>
       </div>
     <% end %>
   </div>

--- a/app/views/routes/index.html.erb
+++ b/app/views/routes/index.html.erb
@@ -1,0 +1,13 @@
+<div class="container">
+  <div class="page-header">
+    <h1>Routes</h1>
+  </div>
+
+  <div class="list-group">
+    <% @routes.each do |route| %>
+      <div class="list-group-item">
+        <%= route.name %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -1,0 +1,5 @@
+<div class="container">
+  <div class="page-header">
+    <h1><%= @route.name %></h1>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   root 'stops#index'
   resources 'stops', only: [:index, :show]
+  
+  resources :routes, only: :index
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root 'stops#index'
   resources 'stops', only: [:index, :show]
-  
-  resources :routes, only: :index
+
+  resources :routes, only: [:index, :show]
 end

--- a/spec/controllers/routes_controller_spec.rb
+++ b/spec/controllers/routes_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe RoutesController, type: :controller do
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/controllers/routes_controller_spec.rb
+++ b/spec/controllers/routes_controller_spec.rb
@@ -7,4 +7,17 @@ RSpec.describe RoutesController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "GET #show" do
+    let(:route) { FactoryGirl.build_stubbed(:route) }
+
+    before do
+      allow(Route).to receive(:find).with(route.id.to_s).and_return(route)
+    end
+
+    it "returns http success" do
+      get :show, params: { id: route }
+      expect(response).to have_http_status(:success)
+    end
+  end
 end

--- a/spec/factories/route.rb
+++ b/spec/factories/route.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :route do
+    route_type '3' # bus
+    route_short_name '95'
+    route_long_name 'Kingshighway'
+  end
+end

--- a/spec/features/routes_list_spec.rb
+++ b/spec/features/routes_list_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+feature 'Lists of Routes', type: :feature do
+  scenario 'visitor finds route by clicking on it' do
+    FactoryGirl.create(
+      :route,
+      route_short_name: '29',
+      route_long_name: 'Princeton Heights'
+    )
+    FactoryGirl.create(
+      :route,
+      route_short_name: '666X',
+      route_long_name: 'West County Express'
+    )
+
+    visit routes_path
+
+    expect(page).to have_content 'Princeton Heights'
+    expect(page).to have_content 'West County Express'
+  end
+end

--- a/spec/features/routes_list_spec.rb
+++ b/spec/features/routes_list_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'Lists of Routes', type: :feature do
   scenario 'visitor finds route by clicking on it' do
-    FactoryGirl.create(
+    p_heights = FactoryGirl.create(
       :route,
       route_short_name: '29',
       route_long_name: 'Princeton Heights'
@@ -17,5 +17,13 @@ feature 'Lists of Routes', type: :feature do
 
     expect(page).to have_content 'Princeton Heights'
     expect(page).to have_content 'West County Express'
+
+    click_link "29 Princeton Heights"
+
+    expect(current_path).to eq route_path(p_heights)
+
+    within "h1" do
+      expect(page).to have_content "29 Princeton Heights"
+    end
   end
 end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -1,9 +1,25 @@
 require 'rails_helper'
 
 describe Route, type: :model do
-  describe "Validations" do
+  describe 'Validations' do
     it { should validate_presence_of :route_short_name }
     it { should validate_presence_of :route_long_name }
     it { should validate_presence_of :route_type }
+  end
+
+  describe '#name' do
+    let(:short_name) { '42' }
+    let(:long_name) { 'Rhodes' }
+    let(:route) do
+      FactoryGirl.create(
+        :route,
+        route_short_name: short_name,
+        route_long_name: long_name
+      )
+    end
+
+    it 'combines the short and long names' do
+      expect(route.name).to eq('42 Rhodes')
+    end
   end
 end


### PR DESCRIPTION
There are some issues here:
- There are multiple Routes (db records) for a route (what we think of when we think of bus routes)
  - e.g. multiple entries for a route called "8 Bates-Morganford"
- Some Routes are the MetroLink lines
- Some Routes are for IL bus routes but these share numbers with MO bus routes
  - e.g. IL's 2 Cahokia vs MO's 2 Red
- For some reason, GL Green Line doesn't have a number ¯\\\_(ツ)\_/¯

This all might be further complicated if we include MCT.